### PR TITLE
cmd/setup-etcd-environment: fix unmarshalling EtcdScaling error

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -495,6 +495,15 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:46779e6e79e6fbe3a2aa135ebfb1ce6606383c03134939d838e322668aa1e4f8"
+  name = "github.com/openshift/cluster-etcd-operator"
+  packages = ["pkg/operator/api"]
+  pruneopts = "NUT"
+  revision = "b206e9559f5f4b77eb5732b042e3de8f75752007"
+  source = "github.com/openshift/cluster-etcd-operator"
+
+[[projects]]
+  branch = "master"
   digest = "1:7595f93ec718b635fc637139b75413aaee09e9a9363c193300397db7bacb2b3b"
   name = "github.com/openshift/library-go"
   packages = [
@@ -1228,6 +1237,7 @@
     "github.com/coreos/ignition/config/validate",
     "github.com/davecgh/go-spew/spew",
     "github.com/ghodss/yaml",
+    "github.com/go-log/log",
     "github.com/golang/glog",
     "github.com/google/renameio",
     "github.com/imdario/mergo",
@@ -1248,6 +1258,7 @@
     "github.com/openshift/client-go/operator/informers/externalversions/operator/v1alpha1",
     "github.com/openshift/client-go/operator/listers/operator/v1alpha1",
     "github.com/openshift/cluster-api/pkg/drain",
+    "github.com/openshift/cluster-etcd-operator/pkg/operator/api",
     "github.com/openshift/library-go/pkg/config/clusteroperator/v1helpers",
     "github.com/openshift/library-go/pkg/operator/v1helpers",
     "github.com/pkg/errors",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -172,3 +172,8 @@ required = [
 [[constraint]]
   name = "github.com/InVisionApp/go-health"
   version = "2.1.0"
+
+[[constraint]]
+  name = "github.com/openshift/cluster-etcd-operator"
+  source = "github.com/openshift/cluster-etcd-operator"
+  branch = "master"

--- a/cmd/setup-etcd-environment/run.go
+++ b/cmd/setup-etcd-environment/run.go
@@ -7,14 +7,16 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"net"
 	"os"
 	"runtime"
 	"strings"
 	"time"
 
+	"k8s.io/apimachinery/pkg/util/wait"
+
 	"github.com/golang/glog"
+	ceoapi "github.com/openshift/cluster-etcd-operator/pkg/operator/api"
 	"github.com/openshift/machine-config-operator/pkg/version"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -42,19 +44,6 @@ var (
 		bootstrapSRV bool
 	}
 )
-
-type EtcdScaling struct {
-	Metadata *metav1.ObjectMeta `json:"metadata,omitempty"`
-	Members  []Member           `json:"members,omitempty"`
-	PodFQDN  string             `json:"podFQDN,omitempty"`
-}
-
-type Member struct {
-	ID         uint64   `json:"ID,omitempty"`
-	Name       string   `json:"name,omitempty"`
-	PeerURLS   []string `json:"peerURLs,omitempty"`
-	ClientURLS []string `json:"clientURLs,omitempty"`
-}
 
 func init() {
 	rootCmd.AddCommand(runCmd)
@@ -134,7 +123,7 @@ func runRunCmd(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return fmt.Errorf("error creating client: %v", err)
 		}
-		var e EtcdScaling
+		var e ceoapi.EtcdScaling
 		// wait forever for success and retry every duration interval
 		wait.PollInfinite(duration, func() (bool, error) {
 			result, err := client.CoreV1().ConfigMaps("openshift-etcd").Get("member-config", metav1.GetOptions{})

--- a/vendor/github.com/openshift/cluster-etcd-operator/LICENSE
+++ b/vendor/github.com/openshift/cluster-etcd-operator/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/openshift/cluster-etcd-operator/pkg/operator/api/scaling.go
+++ b/vendor/github.com/openshift/cluster-etcd-operator/pkg/operator/api/scaling.go
@@ -1,0 +1,67 @@
+package api
+
+import (
+	v1 "github.com/openshift/api/config/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type EtcdScaling struct {
+	Metadata *metav1.ObjectMeta `json:"metadata,omitempty"`
+	Members  []Member           `json:"members,omitempty"`
+	// deprecated pending removal
+	PodFQDN string `json:"podFQDN,omitempty"`
+}
+
+type Member struct {
+	ID         uint64            `json:"ID,omitempty"`
+	Name       string            `json:"name,omitempty"`
+	PeerURLS   []string          `json:"peerURLs,omitempty"`
+	ClientURLS []string          `json:"clientURLs,omitempty"`
+	Conditions []MemberCondition `json:"conditions,omitempty"`
+}
+
+type MemberCondition struct {
+	// type describes the current condition
+	Type MemberConditionType `json:"type"`
+	// status is the status of the condition (True, False, Unknown)
+	Status v1.ConditionStatus `json:"status"`
+	// timestamp for the last update to this condition
+	// +optional
+	LastUpdateTime metav1.Time `json:"lastUpdateTime,omitempty"`
+	// reason is the reason for the condition's last transition.
+	// +optional
+	Reason string `json:"reason,omitempty"`
+	// message is a human-readable explanation containing details about
+	// the transition
+	// +optional
+	Message string `json:"message,omitempty"`
+}
+
+type MemberConditionType string
+
+const (
+	// Ready indicated the member is part of the cluster and endpoint is Ready
+	MemberReady MemberConditionType = "Ready"
+	// Unknown indicated the member condition is unknown and requires further observations to verify
+	MemberUnknown MemberConditionType = "Unknown"
+	// Degraded indicates the member pod is in a degraded state and should be restarted
+	MemberDegraded MemberConditionType = "Degraded"
+	// Remove indicates the member should be removed from the cluster
+	MemberRemove MemberConditionType = "Remove"
+	// MemberAdd is a member who is ready to join cluster but currently has not
+	MemberAdd MemberConditionType = "Add"
+)
+
+func GetMemberCondition(status string) MemberConditionType {
+	switch {
+	case status == string(MemberReady):
+		return MemberReady
+	case status == string(MemberRemove):
+		return MemberRemove
+	case status == string(MemberUnknown):
+		return MemberUnknown
+	case status == string(MemberDegraded):
+		return MemberDegraded
+	}
+	return ""
+}


### PR DESCRIPTION
The discovery container was erroring out because of the change in CEO
EtcdScaling data structure. This PR uses the CEO package to import the
EtcdScaling data structure.

Depends on hexfusion/cluster-etcd-operator#42

