### PR TITLE
*: remove hardcording etcd endpoints and generate them from setup env

### DIFF
--- a/cmd/setup-etcd-environment/run.go
+++ b/cmd/setup-etcd-environment/run.go
@@ -116,6 +116,8 @@ func runRunCmd(cmd *cobra.Command, args []string) error {
 	glog.Infof("dns name is %s", dns)
 
 	exportEnv := make(map[string]string)
+
+	endpoints := make([]string, 0)
 	if _, err := os.Stat(fmt.Sprintf("%s/member", etcdDataDir)); os.IsNotExist(err) && !runOpts.bootstrapSRV && inCluster() {
 		duration := 10 * time.Second
 		wait.PollInfinite(duration, func() (bool, error) {
@@ -162,8 +164,23 @@ func runRunCmd(cmd *cobra.Command, args []string) error {
 			memberList = append(memberList, fmt.Sprintf("%s=https://%s:2380", etcdName, dns))
 			exportEnv["INITIAL_CLUSTER"] = strings.Join(memberList, ",")
 			exportEnv["INITIAL_CLUSTER_STATE"] = "existing"
+			exportEnv["ENDPOINTS"] = strings.Join(endpoints, ",")
 			return true, nil
 		})
+
+		ep, err := client.CoreV1().Endpoints("openshift-etcd").Get("etcd", metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if len(ep.Subsets) >= 1 {
+			if len(ep.Subsets[0].Addresses) == 0 {
+				endpoints = append(endpoints, "https://etcd-bootstrap."+runOpts.discoverySRV+":2379")
+			} else {
+				for _, s := range ep.Subsets[0].Addresses {
+					endpoints = append(endpoints, "https://"+s.IP+":2379")
+				}
+			}
+		}
 	}
 
 	out := os.Stdout

--- a/templates/master/00-master/_base/files/etc-kubernetes-manifests-etcd-member.yaml
+++ b/templates/master/00-master/_base/files/etc-kubernetes-manifests-etcd-member.yaml
@@ -90,7 +90,7 @@ contents:
 
           export ETCDCTL_API=3 ETCDCTL_CACERT=/etc/ssl/etcd/ca.crt ETCDCTL_CERT=$(find /etc/ssl/ -name *peer*crt) ETCDCTL_KEY=$(find /etc/ssl/ -name *peer*key)
 
-          export ETCDCTL_ENDPOINTS=https://"${ETCD_DNS_NAME/etcd-[0-9]/etcd-bootstrap}":2379
+          export ETCDCTL_ENDPOINTS="$ETCD_ENDPOINTS"
 
           until $(etcdctl member list | grep $ETCD_DNS_NAME>/dev/null)
           do


### PR DESCRIPTION
If the endpoint has 0 Ready Addresses, then it assumes that this is
etcd-0, so etcd-bootstrap is the endpoint for it. If the endpoint
has more than 0 ready addresses, this list of ready addresses is used as 
the endpoint. This is will setup appropriate env for restarting the static
pods.

