### PR TITLE
cmd/setup-etcd-env: set ENDPOINTS after it is populated

### DIFF
--- a/cmd/setup-etcd-environment/run.go
+++ b/cmd/setup-etcd-environment/run.go
@@ -116,6 +116,8 @@ func runRunCmd(cmd *cobra.Command, args []string) error {
 	glog.Infof("dns name is %s", dns)
 
 	exportEnv := make(map[string]string)
+
+	endpoints := make([]string, 0)
 	if _, err := os.Stat(fmt.Sprintf("%s/member", etcdDataDir)); os.IsNotExist(err) && !runOpts.bootstrapSRV && inCluster() {
 		duration := 10 * time.Second
 		wait.PollInfinite(duration, func() (bool, error) {
@@ -164,6 +166,21 @@ func runRunCmd(cmd *cobra.Command, args []string) error {
 			exportEnv["INITIAL_CLUSTER_STATE"] = "existing"
 			return true, nil
 		})
+
+		ep, err := client.CoreV1().Endpoints("openshift-etcd").Get("etcd", metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if len(ep.Subsets) >= 1 {
+			if len(ep.Subsets[0].Addresses) == 0 {
+				endpoints = append(endpoints, "https://etcd-bootstrap."+runOpts.discoverySRV+":2379")
+			} else {
+				for _, s := range ep.Subsets[0].Addresses {
+					endpoints = append(endpoints, "https://"+s.IP+":2379")
+				}
+			}
+		}
+		exportEnv["ENDPOINTS"] = strings.Join(endpoints, ",")
 	}
 
 	out := os.Stdout

--- a/templates/master/00-master/_base/files/etc-kubernetes-manifests-etcd-member.yaml
+++ b/templates/master/00-master/_base/files/etc-kubernetes-manifests-etcd-member.yaml
@@ -90,7 +90,7 @@ contents:
 
           export ETCDCTL_API=3 ETCDCTL_CACERT=/etc/ssl/etcd/ca.crt ETCDCTL_CERT=$(find /etc/ssl/ -name *peer*crt) ETCDCTL_KEY=$(find /etc/ssl/ -name *peer*key)
 
-          export ETCDCTL_ENDPOINTS=https://"${ETCD_DNS_NAME/etcd-[0-9]/etcd-bootstrap}":2379
+          export ETCDCTL_ENDPOINTS="$ETCD_ENDPOINTS"
 
           until $(etcdctl member list | grep $ETCD_DNS_NAME>/dev/null)
           do


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Populate endpoints dynamically. This would require RBAC permission for default account in openshift-etcd. This allows for restart controller to successfully replace a failed member as the endpoint value will be calculated in the init container after the restart. Depends on hexfusion/cluster-etcd-operator#46

**- How to verify it**
I exceed into the pods and ran `printenv`.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
