### PR TITLE
*: add ceo image key to render it in MCO template

### DIFF
--- a/cmd/machine-config-operator/bootstrap.go
+++ b/cmd/machine-config-operator/bootstrap.go
@@ -34,6 +34,7 @@ var (
 		keepalivedImage           string
 		kubeCAFile                string
 		kubeClientAgentImage      string
+		clusterEtcdOperatorImage  string
 		mcoImage                  string
 		mdnsPublisherImage        string
 		networkConfigFile         string
@@ -62,6 +63,7 @@ func init() {
 	bootstrapCmd.MarkFlagRequired("etcd-image")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.kubeClientAgentImage, "kube-client-agent-image", "", "Image for Kube Client Agent.")
 	bootstrapCmd.MarkFlagRequired("kube-client-agent-image")
+	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.clusterEtcdOperatorImage, "cluster-etcd-operator-image", "", "Image for Cluster Etcd Operator. An empty string here means the cluster boots without CEO.")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.infraImage, "infra-image", "", "Image for Infra Containers.")
 	bootstrapCmd.MarkFlagRequired("infra-image")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.configFile, "config-file", "", "ClusterConfig ConfigMap file.")
@@ -97,6 +99,7 @@ func runBootstrapCmd(cmd *cobra.Command, args []string) {
 			Etcd:                bootstrapOpts.etcdImage,
 			InfraImage:          bootstrapOpts.infraImage,
 			KubeClientAgent:     bootstrapOpts.kubeClientAgentImage,
+			ClusterEtcdOperator: bootstrapOpts.clusterEtcdOperatorImage,
 			Keepalived:          bootstrapOpts.keepalivedImage,
 			Coredns:             bootstrapOpts.corednsImage,
 			MdnsPublisher:       bootstrapOpts.mdnsPublisherImage,

--- a/cmd/setup-etcd-environment/run.go
+++ b/cmd/setup-etcd-environment/run.go
@@ -7,12 +7,13 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"net"
 	"os"
 	"runtime"
 	"strings"
 	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/golang/glog"
 	"github.com/openshift/machine-config-operator/pkg/version"

--- a/install/0000_80_machine-config-operator_02_images.configmap.yaml
+++ b/install/0000_80_machine-config-operator_02_images.configmap.yaml
@@ -10,6 +10,7 @@ data:
       "etcd": "registry.svc.ci.openshift.org/openshift:etcd",
       "infraImage": "registry.svc.ci.openshift.org/openshift:pod",
       "kubeClientAgentImage": "registry.svc.ci.openshift.org/openshift:kube-client-agent",
+      "clusterEtcdOperatorImage": "registry.svc.ci.openshift.org/openshift:cluster-etcd-operator",
       "keepalivedImage": "registry.svc.ci.openshift.org/openshift:keepalived-ipfailover",
       "corednsImage": "registry.svc.ci.openshift.org/openshift:coredns",
       "mdnsPublisherImage": "registry.svc.ci.openshift.org/openshift:mdns-publisher",

--- a/install/image-references
+++ b/install/image-references
@@ -27,6 +27,10 @@ spec:
     from:
       kind: DockerImage
       name: registry.svc.ci.openshift.org/openshift:kube-client-agent
+  - name: cluster-etcd-operator
+    from:
+      kind: DockerImage
+      name: registry.svc.ci.openshift.org/openshift:cluster-etcd-operator
   - name: cli
     from:
       kind: DockerImage

--- a/install/image-references
+++ b/install/image-references
@@ -27,10 +27,6 @@ spec:
     from:
       kind: DockerImage
       name: registry.svc.ci.openshift.org/openshift:kube-client-agent
-  - name: cluster-etcd-operator
-    from:
-      kind: DockerImage
-      name: registry.svc.ci.openshift.org/openshift:cluster-etcd-operator
   - name: cli
     from:
       kind: DockerImage

--- a/pkg/controller/template/constants.go
+++ b/pkg/controller/template/constants.go
@@ -16,6 +16,9 @@ const (
 	// KubeClientAgentImageKey is the key that references the kube-client-agent image in the controller
 	KubeClientAgentImageKey string = "kubeClientAgentImageKey"
 
+	// ClusterEtcdOperatorImageKey is the key that references the cluster-etcd-operator image in the controller
+	ClusterEtcdOperatorImageKey string = "clusterEtcdOperatorImageKey"
+
 	// KeepalivedKey is the key that references the keepalived-ipfailover image in the controller
 	KeepalivedKey string = "keepalivedImage"
 

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -47,6 +47,7 @@ import (
 	"strings"
 	"time"
 )
+
 type asset struct {
 	bytes []byte
 	info  os.FileInfo
@@ -92,8 +93,8 @@ func (fi bindataFileInfo) Sys() interface{} {
 var _manifestsBaremetalCorednsCorefileTmpl = []byte(`. {
     errors
     health
-    mdns {{ .ControllerConfig.EtcdDiscoveryDomain }} {{`+"`"+`{{.Cluster.MasterAmount}}`+"`"+`}} {{`+"`"+`{{.Cluster.Name}}`+"`"+`}}
-    forward . {{`+"`"+`{{- range $upstream := .DNSUpstreams}} {{$upstream}}{{- end}}`+"`"+`}}
+    mdns {{ .ControllerConfig.EtcdDiscoveryDomain }} {{` + "`" + `{{.Cluster.MasterAmount}}` + "`" + `}} {{` + "`" + `{{.Cluster.Name}}` + "`" + `}}
+    forward . {{` + "`" + `{{- range $upstream := .DNSUpstreams}} {{$upstream}}{{- end}}` + "`" + `}}
     cache 30
     reload
     hosts /etc/coredns/api-int.hosts {{ .ControllerConfig.EtcdDiscoveryDomain }} {
@@ -233,33 +234,33 @@ var _manifestsBaremetalKeepalivedConfTmpl = []byte(`# Configuration template for
 # For more information, see installer/data/data/bootstrap/baremetal/README.md
 # in the installer repo.
 
-vrrp_instance {{`+"`"+`{{.Cluster.Name}}`+"`"+`}}_API {
+vrrp_instance {{` + "`" + `{{.Cluster.Name}}` + "`" + `}}_API {
     state BACKUP
-    interface {{`+"`"+`{{.VRRPInterface}}`+"`"+`}}
-    virtual_router_id {{`+"`"+`{{.Cluster.APIVirtualRouterID }}`+"`"+`}}
+    interface {{` + "`" + `{{.VRRPInterface}}` + "`" + `}}
+    virtual_router_id {{` + "`" + `{{.Cluster.APIVirtualRouterID }}` + "`" + `}}
     priority 50
     advert_int 1
     authentication {
         auth_type PASS
-        auth_pass {{`+"`"+`{{.Cluster.Name}}`+"`"+`}}_api_vip
+        auth_pass {{` + "`" + `{{.Cluster.Name}}` + "`" + `}}_api_vip
     }
     virtual_ipaddress {
-        {{`+"`"+`{{ .Cluster.APIVIP }}`+"`"+`}}/{{`+"`"+`{{ .Cluster.VIPNetmask }}`+"`"+`}}
+        {{` + "`" + `{{ .Cluster.APIVIP }}` + "`" + `}}/{{` + "`" + `{{ .Cluster.VIPNetmask }}` + "`" + `}}
     }
 }
 
-vrrp_instance {{`+"`"+`{{.Cluster.Name}}`+"`"+`}}_DNS {
+vrrp_instance {{` + "`" + `{{.Cluster.Name}}` + "`" + `}}_DNS {
     state MASTER
-    interface {{`+"`"+`{{.VRRPInterface}}`+"`"+`}}
-    virtual_router_id {{`+"`"+`{{.Cluster.DNSVirtualRouterID }}`+"`"+`}}
+    interface {{` + "`" + `{{.VRRPInterface}}` + "`" + `}}
+    virtual_router_id {{` + "`" + `{{.Cluster.DNSVirtualRouterID }}` + "`" + `}}
     priority 140
     advert_int 1
     authentication {
         auth_type PASS
-        auth_pass {{`+"`"+`{{.Cluster.Name}}`+"`"+`}}_dns_vip
+        auth_pass {{` + "`" + `{{.Cluster.Name}}` + "`" + `}}_dns_vip
     }
     virtual_ipaddress {
-        {{`+"`"+`{{ .Cluster.DNSVIP }}`+"`"+`}}/{{`+"`"+`{{ .Cluster.VIPNetmask }}`+"`"+`}}
+        {{` + "`" + `{{ .Cluster.DNSVIP }}` + "`" + `}}/{{` + "`" + `{{ .Cluster.VIPNetmask }}` + "`" + `}}
     }
 }
 `)
@@ -1364,7 +1365,7 @@ func manifestsMachineconfigserverClusterrolebindingYaml() (*asset, error) {
 	return a, nil
 }
 
-var _manifestsMachineconfigserverCsrBootstrapRoleBindingYaml = []byte(`# system-bootstrap-node-bootstrapper lets serviceaccount `+"`"+`openshift-machine-config-operator/node-bootstrapper`+"`"+` tokens and nodes request CSRs.
+var _manifestsMachineconfigserverCsrBootstrapRoleBindingYaml = []byte(`# system-bootstrap-node-bootstrapper lets serviceaccount ` + "`" + `openshift-machine-config-operator/node-bootstrapper` + "`" + ` tokens and nodes request CSRs.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -1398,7 +1399,7 @@ var _manifestsMachineconfigserverCsrRenewalRoleBindingYaml = []byte(`# CSRRenewa
 # certificates.
 #
 # This binding should be altered in the future to hold a list of node
-# names instead of targeting `+"`"+`system:nodes`+"`"+` so we can revoke invidivual
+# names instead of targeting ` + "`" + `system:nodes` + "`" + ` so we can revoke invidivual
 # node's ability to renew its certs.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -1623,8 +1624,8 @@ func manifestsMasterMachineconfigpoolYaml() (*asset, error) {
 var _manifestsOpenstackCorednsCorefileTmpl = []byte(`. {
     errors
     health
-    mdns {{ .ControllerConfig.EtcdDiscoveryDomain }} {{`+"`"+`{{.Cluster.MasterAmount}}`+"`"+`}} {{`+"`"+`{{.Cluster.Name}}`+"`"+`}}
-    forward . {{`+"`"+`{{- range $upstream := .DNSUpstreams}} {{$upstream}}{{- end}}`+"`"+`}}
+    mdns {{ .ControllerConfig.EtcdDiscoveryDomain }} {{` + "`" + `{{.Cluster.MasterAmount}}` + "`" + `}} {{` + "`" + `{{.Cluster.Name}}` + "`" + `}}
+    forward . {{` + "`" + `{{- range $upstream := .DNSUpstreams}} {{$upstream}}{{- end}}` + "`" + `}}
     cache 30
     reload
     hosts /etc/coredns/api-int.hosts {{ .ControllerConfig.EtcdDiscoveryDomain }} {
@@ -1764,33 +1765,33 @@ var _manifestsOpenstackKeepalivedConfTmpl = []byte(`# Configuration template for
 # For more information, see installer/data/data/bootstrap/baremetal/README.md
 # in the installer repo.
 
-vrrp_instance {{`+"`"+`{{.Cluster.Name}}`+"`"+`}}_API {
+vrrp_instance {{` + "`" + `{{.Cluster.Name}}` + "`" + `}}_API {
     state BACKUP
-    interface {{`+"`"+`{{.VRRPInterface}}`+"`"+`}}
-    virtual_router_id {{`+"`"+`{{.Cluster.APIVirtualRouterID }}`+"`"+`}}
+    interface {{` + "`" + `{{.VRRPInterface}}` + "`" + `}}
+    virtual_router_id {{` + "`" + `{{.Cluster.APIVirtualRouterID }}` + "`" + `}}
     priority 50
     advert_int 1
     authentication {
         auth_type PASS
-        auth_pass {{`+"`"+`{{.Cluster.Name}}`+"`"+`}}_api_vip
+        auth_pass {{` + "`" + `{{.Cluster.Name}}` + "`" + `}}_api_vip
     }
     virtual_ipaddress {
-        {{`+"`"+`{{ .Cluster.APIVIP }}`+"`"+`}}/{{`+"`"+`{{ .Cluster.VIPNetmask }}`+"`"+`}}
+        {{` + "`" + `{{ .Cluster.APIVIP }}` + "`" + `}}/{{` + "`" + `{{ .Cluster.VIPNetmask }}` + "`" + `}}
     }
 }
 
-vrrp_instance {{`+"`"+`{{.Cluster.Name}}`+"`"+`}}_DNS {
+vrrp_instance {{` + "`" + `{{.Cluster.Name}}` + "`" + `}}_DNS {
     state MASTER
-    interface {{`+"`"+`{{.VRRPInterface}}`+"`"+`}}
-    virtual_router_id {{`+"`"+`{{.Cluster.DNSVirtualRouterID }}`+"`"+`}}
+    interface {{` + "`" + `{{.VRRPInterface}}` + "`" + `}}
+    virtual_router_id {{` + "`" + `{{.Cluster.DNSVirtualRouterID }}` + "`" + `}}
     priority 140
     advert_int 1
     authentication {
         auth_type PASS
-        auth_pass {{`+"`"+`{{.Cluster.Name}}`+"`"+`}}_dns_vip
+        auth_pass {{` + "`" + `{{.Cluster.Name}}` + "`" + `}}_dns_vip
     }
     virtual_ipaddress {
-        {{`+"`"+`{{ .Cluster.DNSVIP }}`+"`"+`}}/{{`+"`"+`{{ .Cluster.VIPNetmask }}`+"`"+`}}
+        {{` + "`" + `{{ .Cluster.DNSVIP }}` + "`" + `}}/{{` + "`" + `{{ .Cluster.VIPNetmask }}` + "`" + `}}
     }
 }
 `)

--- a/pkg/operator/bootstrap.go
+++ b/pkg/operator/bootstrap.go
@@ -130,16 +130,17 @@ func RenderBootstrap(
 	spec.PullSecret = nil
 	spec.OSImageURL = imgs.MachineOSContent
 	spec.Images = map[string]string{
-		templatectrl.EtcdImageKey:            imgs.Etcd,
-		templatectrl.SetupEtcdEnvKey:         imgs.MachineConfigOperator,
-		templatectrl.GCPRoutesControllerKey:  imgs.MachineConfigOperator,
-		templatectrl.InfraImageKey:           imgs.InfraImage,
-		templatectrl.KubeClientAgentImageKey: imgs.KubeClientAgent,
-		templatectrl.KeepalivedKey:           imgs.Keepalived,
-		templatectrl.CorednsKey:              imgs.Coredns,
-		templatectrl.MdnsPublisherKey:        imgs.MdnsPublisher,
-		templatectrl.HaproxyKey:              imgs.Haproxy,
-		templatectrl.BaremetalRuntimeCfgKey:  imgs.BaremetalRuntimeCfg,
+		templatectrl.EtcdImageKey:                imgs.Etcd,
+		templatectrl.SetupEtcdEnvKey:             imgs.MachineConfigOperator,
+		templatectrl.GCPRoutesControllerKey:      imgs.MachineConfigOperator,
+		templatectrl.InfraImageKey:               imgs.InfraImage,
+		templatectrl.KubeClientAgentImageKey:     imgs.KubeClientAgent,
+		templatectrl.ClusterEtcdOperatorImageKey: imgs.ClusterEtcdOperator,
+		templatectrl.KeepalivedKey:               imgs.Keepalived,
+		templatectrl.CorednsKey:                  imgs.Coredns,
+		templatectrl.MdnsPublisherKey:            imgs.MdnsPublisher,
+		templatectrl.HaproxyKey:                  imgs.Haproxy,
+		templatectrl.BaremetalRuntimeCfgKey:      imgs.BaremetalRuntimeCfg,
 	}
 
 	config := getRenderConfig("", string(filesData[kubeAPIServerServingCA]), spec, &imgs.RenderConfigImages, infra.Status.APIServerInternalURL)

--- a/pkg/operator/images.go
+++ b/pkg/operator/images.go
@@ -29,6 +29,7 @@ type ControllerConfigImages struct {
 	Etcd                string `json:"etcd"`
 	InfraImage          string `json:"infraImage"`
 	KubeClientAgent     string `json:"kubeClientAgentImage"`
+	ClusterEtcdOperator string `json:"clusterEtcdOperatorImage"`
 	Keepalived          string `json:"keepalivedImage"`
 	Coredns             string `json:"corednsImage"`
 	MdnsPublisher       string `json:"mdnsPublisherImage"`

--- a/pkg/operator/render_test.go
+++ b/pkg/operator/render_test.go
@@ -2,9 +2,10 @@ package operator
 
 import (
 	"fmt"
-	configv1 "github.com/openshift/api/config/v1"
 	"strings"
 	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
 )
 
 func TestClusterDNSIP(t *testing.T) {

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -208,16 +208,17 @@ func (optr *Operator) syncRenderConfig(_ *renderConfig) error {
 	spec.PullSecret = &corev1.ObjectReference{Namespace: "openshift-config", Name: "pull-secret"}
 	spec.OSImageURL = imgs.MachineOSContent
 	spec.Images = map[string]string{
-		templatectrl.EtcdImageKey:            imgs.Etcd,
-		templatectrl.SetupEtcdEnvKey:         imgs.MachineConfigOperator,
-		templatectrl.GCPRoutesControllerKey:  imgs.MachineConfigOperator,
-		templatectrl.InfraImageKey:           imgs.InfraImage,
-		templatectrl.KubeClientAgentImageKey: imgs.KubeClientAgent,
-		templatectrl.KeepalivedKey:           imgs.Keepalived,
-		templatectrl.CorednsKey:              imgs.Coredns,
-		templatectrl.MdnsPublisherKey:        imgs.MdnsPublisher,
-		templatectrl.HaproxyKey:              imgs.Haproxy,
-		templatectrl.BaremetalRuntimeCfgKey:  imgs.BaremetalRuntimeCfg,
+		templatectrl.EtcdImageKey:                imgs.Etcd,
+		templatectrl.SetupEtcdEnvKey:             imgs.MachineConfigOperator,
+		templatectrl.GCPRoutesControllerKey:      imgs.MachineConfigOperator,
+		templatectrl.InfraImageKey:               imgs.InfraImage,
+		templatectrl.KubeClientAgentImageKey:     imgs.KubeClientAgent,
+		templatectrl.ClusterEtcdOperatorImageKey: imgs.ClusterEtcdOperator,
+		templatectrl.KeepalivedKey:               imgs.Keepalived,
+		templatectrl.CorednsKey:                  imgs.Coredns,
+		templatectrl.MdnsPublisherKey:            imgs.MdnsPublisher,
+		templatectrl.HaproxyKey:                  imgs.Haproxy,
+		templatectrl.BaremetalRuntimeCfgKey:      imgs.BaremetalRuntimeCfg,
 	}
 
 	// create renderConfig

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -11,10 +11,10 @@ import (
 
 	igntypes "github.com/coreos/ignition/config/v2_2/types"
 	yaml "github.com/ghodss/yaml"
-	"github.com/stretchr/testify/assert"
 	v1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	daemonconsts "github.com/openshift/machine-config-operator/pkg/daemon/constants"
 	"github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned/fake"
+	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 )
 

--- a/templates/master/00-master/_base/files/etc-kubernetes-manifests-etcd-member.yaml
+++ b/templates/master/00-master/_base/files/etc-kubernetes-manifests-etcd-member.yaml
@@ -38,7 +38,7 @@ contents:
             fieldRef:
               fieldPath: metadata.name
       - name: certs
-        image: "{{.Images.kubeClientAgentImageKey}}"
+        image: {{if .Images.clusterEtcdOperatorImageKey}}"{{.Images.clusterEtcdOperatorImageKey}}"{{else}}"{{.Images.kubeClientAgentImageKey}}"{{end}}
         command:
         - /bin/sh
         - -c
@@ -46,26 +46,29 @@ contents:
           #!/bin/sh
           set -euxo pipefail
 
+          {{if .Images.clusterEtcdOperatorImageKey}}
+            COMMAND="cluster-etcd-operator mount"
+          {{else}}
+            COMMAND="kube-client-agent request"
+          {{end}}
+
           source /run/etcd/environment
 
           [ -e /etc/ssl/etcd/system:etcd-server:${ETCD_DNS_NAME}.crt -a \
             -e /etc/ssl/etcd/system:etcd-server:${ETCD_DNS_NAME}.key ] || \
-            kube-client-agent \
-              mount \
+            $COMMAND \
                 --assetsdir=/etc/ssl/etcd \
                 --commonname=system:etcd-server:${ETCD_DNS_NAME}
 
           [ -e /etc/ssl/etcd/system:etcd-peer:${ETCD_DNS_NAME}.crt -a \
             -e /etc/ssl/etcd/system:etcd-peer:${ETCD_DNS_NAME}.key ] || \
-            kube-client-agent \
-              mount \
+            $COMMAND \
                 --assetsdir=/etc/ssl/etcd \
                 --commonname=system:etcd-peer:${ETCD_DNS_NAME}
 
           [ -e /etc/ssl/etcd/system:etcd-metric:${ETCD_DNS_NAME}.crt -a \
             -e /etc/ssl/etcd/system:etcd-metric:${ETCD_DNS_NAME}.key ] || \
-            kube-client-agent \
-              mount \
+            $COMMAND \
                 --assetsdir=/etc/ssl/etcd \
                 --commonname=system:etcd-metric:${ETCD_DNS_NAME}
 
@@ -77,6 +80,7 @@ contents:
           mountPath: /etc/ssl/etcd/
         - name: sa
           mountPath: /var/run/secrets/kubernetes.io/serviceaccount/
+    {{if .Images.clusterEtcdOperatorImageKey}}
       - name: membership
         image: "{{.Images.etcdKey}}"
         command:
@@ -103,6 +107,7 @@ contents:
           mountPath: /run/etcd/
         - name: certs
           mountPath: /etc/ssl/etcd/
+    {{end}}
       containers:
       - name: etcd-member
         image: "{{.Images.etcdKey}}"


### PR DESCRIPTION
This will serve as a feature gate. An empty image field will mean
 cluster-etcd-operator is not enabled and the cluster is
bootstrapping 4.2 style. A lot left to do for making etcd-member
manifest file boot without 4.2 but this is a start. 